### PR TITLE
postfix/pipe[30312]: warning: pipe flag `D' requires trap_destination_recipient_limit = 1

### DIFF
--- a/docker/postfix/etc/postfix/main.cf
+++ b/docker/postfix/etc/postfix/main.cf
@@ -27,4 +27,5 @@ smtpd_sasl_local_domain =
 smtpd_recipient_restrictions = permit_mynetworks permit_sasl_authenticated reject_unauth_destination
 broken_sasl_auth_clients = yes
 #
+trap_destination_recipient_limit = 1
 default_transport=trap


### PR DESCRIPTION
`flags=FDRq` in master.cf

- https://stackoverflow.com/questions/34266699/warning-pipe-flag-d-requires-dovecot-destination-recipient-limit-1